### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -206,7 +206,7 @@ For full coding standards, testing patterns, architecture guidelines, and commit
 
 ## Coding Conventions
 
-- **Language standard:** C99 with `#define _GNU_SOURCE` at the top of every source file
+- **Language standard:** C99 (`set(CMAKE_C_STANDARD 99)`). Only the Meltdown source (`Meltdown/paboldin/script.c`) defines `_GNU_SOURCE` (for `ucontext`/`REG_RIP`); the Spectre and test sources do not
 - **Assembly syntax:** AT&T syntax for inline `asm` blocks (GCC default)
 - **Probe array sizing:** 256 entries × 512 or 4096 bytes per entry (to span cache lines)
 - **Cache line stride:** Minimum 512 bytes between probe array entries (typically 4096 for safety)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- corrected the `_GNU_SOURCE` convention in `CLAUDE.md` and `.github/copilot-instructions.md` to note only the Meltdown source defines it, not every source file
+
 ## [0.2.0] - 2026-05-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ All exploits use the Flush+Reload side channel: flush a 256-entry probe array fr
 
 ## Conventions
 
-- C99 with `#define _GNU_SOURCE` at the top of every source file.
+- C99 (`set(CMAKE_C_STANDARD 99)`). Only the Meltdown source (`Meltdown/paboldin/script.c`) defines `_GNU_SOURCE`, for `ucontext`/`REG_RIP`; the Spectre and test sources do not.
 - Inline assembly uses AT&T syntax.
 - Probe arrays: 256 entries x 512 or 4096 bytes to span separate cache lines.
 - Timing: prefer `rdtscp` (serializing) over `rdtsc`.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.