### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,7 +85,7 @@ make -f Makefile.txt             # Standalone build with -O2 -msse2
 cd Meltdown/paboldin
 # Optional: auto-detect rdtscp support
 bash detect_rdtscp.sh            # Generates rdtscp.h
-make -f Makefile.txt             # Produces ./script binary
+make -f Makefile.txt             # Produces ./meltdown binary (run.sh expects it)
 ./run.sh                         # Full vulnerability test
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- corrected the standalone Meltdown build comment in `.github/copilot-instructions.md` to note it produces the `./meltdown` binary (as `run.sh` expects), not `./script`
+
 ## [0.2.1] - 2026-06-03
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.