### PR TITLE
feat(skills): added a Copilot code-review skill

### DIFF
--- a/.changes/unreleased/1787760793450732995-8f8d.yaml
+++ b/.changes/unreleased/1787760793450732995-8f8d.yaml
@@ -1,0 +1,3 @@
+kind: 'Added'
+body: 'added a tailored `code-review` skill under `.github/skills/` so GitHub Copilot reviews changes against the [rios0rios0/guide](https://github.com/rios0rios0/guide/wiki) standards and this repository''s own load-bearing invariants'
+time: '2026-08-26T16:13:13.450651641Z'

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: code-review
+description: "Review pull requests and diffs in speculative-execution — the Meltdown and Spectre proof-of-concept research collection in C99 — against the rios0rios0/guide standards, with extra weight on preserving upstream reference exploits verbatim, CMake target hygiene, and the educational framing. Use when reviewing a PR, a branch, or staged changes here."
+---
+
+# Code review — `speculative-execution`
+
+This repository collects published Meltdown (CVE-2017-5754) and Spectre (CVE-2017-5753) proofs of concept from Jann Horn et al., paboldin and rootkea alongside original cross-process Spectre variants and timing utilities, all C99 for x86/x86-64 Linux and built by one `CMakeLists.txt` with ten targets.
+
+## When to use this skill
+
+Use it whenever you are asked to review a pull request, a diff, a branch, or staged changes
+in this repository — and before opening a pull request of your own, as a self-check. It is a
+**review** skill: it produces findings, not commits.
+
+## Source of truth
+
+The canonical engineering standards live in the
+**[rios0rios0/guide wiki](https://github.com/rios0rios0/guide/wiki)**. This file is a
+repo-tailored index into that guide plus the rules that only apply here. Precedence, highest
+first:
+
+1. This repository's `.github/copilot-instructions.md`, `CLAUDE.md`, and `CONTRIBUTING.md` —
+   they describe *this* codebase and its load-bearing invariants.
+2. The **rios0rios0/guide** wiki — the shared standard.
+3. General language idiom.
+
+When the guide and a general convention disagree, the guide wins. When this file and the
+guide disagree, the guide wins and this file should be corrected in the same pull request.
+
+### Guide pages that apply here
+
+| Topic | Page |
+|-------|------|
+| Git Flow — branches, commits, SemVer, breaking changes | [Git-Flow](https://github.com/rios0rios0/guide/wiki/Git-Flow) |
+| Documentation & Change Control — changelog and docs discipline | [Documentation-&-Change-Control](https://github.com/rios0rios0/guide/wiki/Documentation-&-Change-Control) |
+| CHANGELOG Formatting — capitalisation and backticks | [CHANGELOG-Formatting](https://github.com/rios0rios0/guide/wiki/CHANGELOG-Formatting) |
+| Security — OWASP checklist, secret hygiene, SAST | [Security](https://github.com/rios0rios0/guide/wiki/Security) |
+| CI & CD — pipeline stages and the local quality gates | [CI-&-CD](https://github.com/rios0rios0/guide/wiki/CI-&-CD) |
+| Code Style — baseline naming and the operations vocabulary | [Code-Style](https://github.com/rios0rios0/guide/wiki/Code-Style) |
+
+## How to run the review
+
+1. **Establish the range.** Resolve the default branch with
+   `git symbolic-ref refs/remotes/origin/HEAD` (strip `refs/remotes/origin/`; fall back to `main`),
+   then read the diff with `git diff <default>...HEAD` and the file list with
+   `git diff <default>...HEAD --name-only`.
+2. **Read whole files, not just hunks.** A hunk cannot show a layering violation, a missing
+   test, or a duplicated helper. Open every changed file in full, plus the files it imports
+   from the layer below.
+3. **Check the change set as a unit** — not only the code. A change that alters behaviour,
+   configuration, or architecture is incomplete without its changelog entry and its
+   documentation update, and that omission is a finding in its own right.
+4. **Map every finding to a rule.** Each finding must name the rule it breaks and link the
+   guide page (or the repository file) that states it. A comment that cannot be traced to a
+   rule is a suggestion, not a defect — label it as such.
+5. **Report, do not rewrite.** Produce the review in the output format below. Only edit files
+   when the request explicitly asks for fixes.
+
+## What matters most in `speculative-execution`
+
+These are the checks that catch real defects in this repository. Work through
+them before the generic ones.
+
+- **Third-party reference exploits stay verbatim.** `Spectre/jann_horn_et_al/`, `Spectre/rootkea/`, and `Meltdown/paboldin/` reproduce published code; "improving" them destroys their value as references and their attribution. Original work belongs in `Spectre/rios0rios0/`. **Critical.**
+- **Optimisation flags are part of the experiment.** The Flush+Reload timing depends on `-O2`, `-msse2`, and the absence of reordering around `clflush`/`_mm_clflush`. Changing a flag, or letting the compiler eliminate the "dead" probe access, makes the PoC stop working for reasons that look like a hardware difference.
+- **`rdtscp` detection is a runtime property.** `detect_rdtscp.sh` generates `rdtscp.h` with either `rdtscp` or `rdtsc`+`mfence`; hard-coding one breaks the other class of machine.
+- **A new file needs a CMake target.** `CMakeLists.txt` carries all ten targets — a source added without one silently never builds.
+- **`/proc/pagemap` access needs a privilege check with a clear message.** The cross-process attacker and `VirtAddress.c` read it; failing silently looks like the exploit not working.
+- **Victim processes have documented lifetimes** — `victim.c` is single-shot and exits after one call, `victim2.c` loops and prints its PID and virtual address. Changing one breaks the attacker's assumptions.
+- **The framing stays educational.** This is published academic material for authorised research; a change that turns a demonstration into a packaged, general-purpose extraction tool is out of scope for this repository.
+- C99 for x86/x86-64 Linux; keep intrinsics behind the existing headers rather than sprinkling inline assembly.
+
+### Commands a reviewer should be able to quote
+
+```bash
+cmake -S . -B build && cmake --build build
+./Meltdown/paboldin/run.sh
+./Meltdown/paboldin/detect_rdtscp.sh
+```
+
+## Tests
+
+There is no automated test suite — the `Tests/` directory holds timing and address-translation utilities, not unit tests. Verification is building every CMake target and running the affected PoC on a machine where it is expected to work, then confirming the reference exploits still behave as published.
+
+## Documentation and change control
+
+See [Documentation & Change Control](https://github.com/rios0rios0/guide/wiki/Documentation-&-Change-Control) and
+[CHANGELOG Formatting](https://github.com/rios0rios0/guide/wiki/CHANGELOG-Formatting).
+
+This repository uses **chlog fragments**. `CHANGELOG.md` is generated and is never edited by
+hand.
+
+- Every change ships a fragment created with `chlog new --kind <Kind> --body "…"`, staged in
+  the **same commit** as the code. Kinds: `Added`, `Changed`, `Deprecated`, `Removed`,
+  `Fixed`, `Security`.
+- A backward-incompatible change to the public interface additionally carries `--breaking`.
+  The kind alone never triggers a major bump.
+- A hand-edited `CHANGELOG.md`, or a code change with no fragment under
+  `.changes/unreleased/`, is a **Critical** finding — `chlog check` fails the build for it.
+- Fragment bodies start with a lowercase verb in simple past tense, capitalise proper nouns
+  (GitHub, Go, Docker), and wrap code identifiers and versions in backticks.
+- `README.md` is updated whenever usage, setup, configuration, or architecture changes;
+  `.github/copilot-instructions.md` and `CLAUDE.md` whenever the workflow, commands, or
+  structure changes. Documentation and code ship in one commit.
+
+## Git Flow and pull-request hygiene
+
+See [Git Flow](https://github.com/rios0rios0/guide/wiki/Git-Flow) and [Merge Guide](https://github.com/rios0rios0/guide/wiki/Merge-Guide).
+
+- Branch names are `feat/`, `fix/`, `refactor/`, `chore/`, `test/`, or `docs/` followed by a
+  ticket ID or a short slug — `feat/TICKET-000`, `fix/input-mask`.
+- Commit subjects are `type(SCOPE): message`: simple past tense (`added`, `fixed`, `changed`,
+  `removed`), lowercase first word, no trailing period, code identifiers in backticks.
+- Branches are synchronised with `git rebase`, never `git merge`. A merge commit from the
+  default branch inside a feature branch is a finding.
+- Breaking changes are flagged in **three** places: the commit footer
+  (`**BREAKING CHANGE:** …`), the changelog, and the pull-request description. One or two of
+  the three is not enough.
+- Versions follow [SemVer](https://semver.org/): MAJOR for incompatible changes, MINOR for
+  features, PATCH for fixes.
+
+## Security
+
+See [Security](https://github.com/rios0rios0/guide/wiki/Security).
+
+- **No hard-coded secrets.** API keys, tokens, passwords, and private keys belong in
+  environment variables or a secret manager — never in source, tests, fixtures, or the
+  changelog. A secret that reaches a commit must be rotated, not merely deleted.
+- **Never write a PEM header sentinel or a realistic key shape into a fixture**
+  (`ghp_…`, `sk-…`, `AKIA…`, `xoxb-…`, JWT-shaped strings, or the dashed `BEGIN …` banners).
+  Gitleaks matches the shape, not the value, so a placeholder that merely *looks* like a
+  credential fails the pipeline. Use inert placeholders such as `fixture-token-placeholder`.
+- **Suppressions must be justified.** Entries in `.gitleaksignore`, `.trivyignore`,
+  `.semgrepignore`, or `.codeql-false-positives` need a fingerprint, a dated comment, and a
+  reason. A suppression added to silence a real finding is a Critical.
+- Validate and sanitise every external input; use parameterised queries; apply least
+  privilege; keep secrets out of logs.
+- Dependency manifest changes are reviewed for new transitive vulnerabilities. When a fix
+  exists, bump the version rather than suppressing the finding.
+
+## What not to flag
+
+A review that raises noise gets ignored. Do not report these:
+
+- The coding style of the vendored reference exploits.
+- Hard-coded cache-size constants in `Tests/CacheTime2.c` — they are the experiment's parameters.
+- Anything the guide does not require and this file does not list, unless it is a genuine correctness or security defect — say so plainly and label it a Suggestion.
+
+## Review output format
+
+```
+## Code review: <branch or PR>
+
+### Critical (must fix before merge)
+- `path/to/file.ext:LINE` — <what is wrong> — violates <rule> (<guide page or repo file>)
+
+### Warning (should fix)
+- `path/to/file.ext:LINE` — <what is wrong> — violates <rule>
+
+### Suggestion (optional)
+- `path/to/file.ext:LINE` — <improvement>
+
+### Change-control checklist
+- [ ] Changelog entry present for every behavioural change
+- [ ] `README.md` updated if usage, setup, or architecture changed
+- [ ] `.github/copilot-instructions.md` and `CLAUDE.md` updated if the workflow, commands, or structure changed
+- [ ] Commit messages follow `type(SCOPE): message` in simple past tense
+- [ ] Breaking changes flagged in the commit footer, the changelog, and the PR description
+
+### Verdict: APPROVE / REQUEST CHANGES
+<one paragraph: the blocking findings, or why the change is ready>
+```
+
+## Severity
+
+| Severity       | Use for                                                                                                                            |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------|
+| **Critical**   | Broken dependency direction, a leaked secret, an injection or authentication flaw, a missing changelog entry, a banned mock library, a load-bearing invariant broken, a test deleted rather than fixed. |
+| **Warning**    | Naming that departs from the guide, a missing test for a new branch of logic, an unexplained magic value, a stale README or instructions file, a `switch` that should be a map. |
+| **Suggestion** | Readability, consistency with neighbouring modules, and performance ideas that no rule mandates.                                     |
+
+Rank findings most severe first, and state plainly when nothing blocks the merge — an empty
+Critical section is a valid, useful review.


### PR DESCRIPTION
## What

Adds `.github/skills/code-review/SKILL.md` — a [GitHub Copilot agent skill](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
that Copilot discovers automatically for anyone working in this repository.

> Review pull requests and diffs in speculative-execution — the Meltdown and Spectre proof-of-concept research collection in C99 — against the rios0rios0/guide standards, with extra weight on preserving upstream reference exploits verbatim, CMake target hygiene, and the educational framing. Use when reviewing a PR, a branch, or staged changes here.

## Why

`.github/copilot-instructions.md` already tells Copilot **how this code works**. This skill covers
the other half — **how a change is judged**: it teaches Copilot to review pull requests, diffs, and
staged changes against the standards in [rios0rios0/guide](https://github.com/rios0rios0/guide/wiki)
instead of against generic best practice.

## What is in it

- **A precedence rule** — this repository's `.github/copilot-instructions.md`, `CLAUDE.md`, and
  `CONTRIBUTING.md` first; then the guide; then general language idiom.
- **A linked index of the 6 guide pages that apply here**, so every finding can cite the rule
  it comes from.
- **A repository-specific checklist first** — 8 checks covering the load-bearing invariants of
  *this* codebase, because those are what catch real defects.
- **The shared guide rules** — layering and dependency direction, language conventions, BDD tests and
  the mock-library ban, chlog fragments, Git Flow and the three-place breaking-change rule, secret
  hygiene and the SAST gates.
- **A "what not to flag" section**, so the review stays signal rather than noise.
- **A fixed output format and severity scale**, so reviews read the same way across every repository.

## Notes

- The skill is tailored per repository: the invariants, commands, layout, and known non-issues are
  different in each one.
- The change is recorded as a chlog fragment under `.changes/unreleased/`; `CHANGELOG.md` is
  untouched, as it is generated.
- No behaviour, build, or CI change — one Markdown file plus one changelog fragment.

Part of a set adding the same skill, individually tailored, to every non-fork `rios0rios0`
repository.
