### PR TITLE
chore(claude): added the Claude workflows from pipelines

### DIFF
--- a/.changes/unreleased/1787860000000000000-c1de.yaml
+++ b/.changes/unreleased/1787860000000000000-c1de.yaml
@@ -1,0 +1,3 @@
+kind: 'Added'
+body: 'added the Claude automated code review and `@claude` mention responder workflows, `claude-review.yaml` and `claude-mention.yaml`, matching the `reusable-claude-review.yaml` / `reusable-claude-mention.yaml` definitions they call in `rios0rios0/pipelines`, authenticating with the `CLAUDE_CODE_OAUTH_TOKEN` secret'
+time: '2026-08-27T18:00:00.000000000Z'

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ This repository contains educational proof-of-concept (PoC) implementations of t
 
 **Technology Stack:** C99 (`_GNU_SOURCE`), inline x86/x86-64 AT&T assembly, `rdtscp`/`rdtsc`, `clflush` (`_mm_clflush`), `sigaction`, `sched_setaffinity`, CMake 3.13+
 
-**No CI/CD pipelines and no automated tests** -- this is a research/educational project.
+**No build or deployment pipelines and no automated tests** -- this is a research/educational project. The only workflows are the Claude review and `@claude` mention ones.
 
 ## Working Effectively
 
@@ -183,7 +183,7 @@ All exploits in this repository use the same fundamental technique:
 
 ## CI/CD Pipeline
 
-There are **no CI/CD pipelines** in this repository. It is a standalone research project with no automated build, test, or deployment workflows.
+There are **no build, test or deployment pipelines** in this repository. It is a standalone research project. The only workflows are `.github/workflows/claude-review.yaml` and `.github/workflows/claude-mention.yaml`, which call the shared Claude reusable workflows in `rios0rios0/pipelines` and need the `CLAUDE_CODE_OAUTH_TOKEN` secret.
 
 ## Development Workflow
 

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -1,0 +1,23 @@
+name: 'Claude Mention'
+
+on:
+  issue_comment:
+    types: ['created']
+  pull_request_review_comment:
+    types: ['created']
+  issues:
+    types: ['opened', 'assigned']
+  pull_request_review:
+    types: ['submitted']
+
+jobs:
+  claude-mention:
+    uses: 'rios0rios0/pipelines/.github/workflows/reusable-claude-mention.yaml@main'
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    permissions:
+      contents: 'write'
+      pull-requests: 'write'
+      issues: 'write'
+      id-token: 'write'
+      actions: 'read'

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -1,0 +1,16 @@
+name: 'Claude Code Review'
+
+on:
+  pull_request:
+    types: ['opened', 'synchronize', 'ready_for_review', 'reopened']
+
+jobs:
+  claude-review:
+    uses: 'rios0rios0/pipelines/.github/workflows/reusable-claude-review.yaml@main'
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    permissions:
+      contents: 'read'
+      pull-requests: 'write'
+      issues: 'write'
+      id-token: 'write'


### PR DESCRIPTION
## What

Adds the two Claude workflows, so this repository gets an automated review on every pull request and answers `@claude` mentions.

- **added** `.github/workflows/claude-review.yaml` — automated review on every PR
- **added** `.github/workflows/claude-mention.yaml` — answers `@claude` in issues, PR comments and reviews

Both are thin callers of the reusable definitions in [`rios0rios0/pipelines`](https://github.com/rios0rios0/pipelines):

```yaml
jobs:
  claude-review:
    uses: 'rios0rios0/pipelines/.github/workflows/reusable-claude-review.yaml@main'
    secrets:
      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
```

## Naming

The definition carries a `reusable-` prefix; the caller drops it. So a file named `claude-review.yaml` is always *this repository's* workflow, and `reusable-claude-review.yaml` is always the shared definition it calls — including inside `rios0rios0/pipelines`, which now names its own callers exactly like every other consumer.

| In `rios0rios0/pipelines` | In this repository |
|---|---|
| `reusable-claude-review.yaml` | `claude-review.yaml` |
| `reusable-claude-mention.yaml` | `claude-mention.yaml` |

## Authentication

`CLAUDE_CODE_OAUTH_TOKEN` is passed **explicitly** rather than with `secrets: inherit`, which Semgrep's `yaml.github-actions.security.secrets-inherit` rule fails. This repository already holds the secret.

## Ordering

The definitions are added by **rios0rios0/pipelines#625**. Until that merges, the `Claude Code Review` check here cannot resolve its `uses:` and will fail — re-run it once #625 is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6B21LbgQKbpL1JzDdBXDe
